### PR TITLE
Fix add comment related issues

### DIFF
--- a/lively.collab/comments/commentBrowser.js
+++ b/lively.collab/comments/commentBrowser.js
@@ -25,9 +25,7 @@ export class CommentBrowser extends Window {
   }
 
   static async addCommentForMorph (comment, morph) {
-    if (CommentBrowser.isOpen()) {
-      await instance.addCommentForMorph(comment, morph);
-    }
+    await instance.addCommentForMorph(comment, morph);
   }
 
   static async initializeCommentBrowser () {


### PR DESCRIPTION
Should be merged before merging #9 

This PR solves the issue, when adding a comment to a morph.
There is now an array with comment morphs per comment group morph, these are the single source of truth regarding comment existence.
They are added to the submorphs when necessary.

closes https://github.com/hpi-swa-lab/BP2020RH1/issues/72

Co-authored-by: linusha <linusha@users.noreply.github.com>
