### PR TITLE
Fix placement of comment indicators when they were hidden

### DIFF
--- a/lively.collab/comments/commentIndicator.js
+++ b/lively.collab/comments/commentIndicator.js
@@ -64,6 +64,8 @@ export class CommentIndicator extends Label {
   }
 
   display () {
+    this.connectMorphs();
+    this.alignWithMorph();
     $world.addMorph(this);
   }
 

--- a/lively.collab/comments/commentMorph.js
+++ b/lively.collab/comments/commentMorph.js
@@ -242,7 +242,7 @@ export class CommentMorph extends Morph {
   }
 
   showCommentIndicator () {
-    this.commentIndicator.display();
+    if (!this.comment.resolved) { this.commentIndicator.display(); }
   }
 
   delete () {


### PR DESCRIPTION
when the comment browser was closed or a comment was resolved and unresolved the indicators didn't move correctly with the correlating morph