### PR TITLE
Fix: Show second indicator on creation

### DIFF
--- a/lively.collab/comments/commentBrowser.js
+++ b/lively.collab/comments/commentBrowser.js
@@ -23,6 +23,10 @@ export class CommentBrowser extends Window {
     return instance && $world.get('comment browser');
   }
 
+  static showsArchive () {
+    return !!instance.showsResolvedComments;
+  }
+
   static async removeCommentForMorph (comment, morph) {
     await instance.removeCommentForMorph(comment, morph);
   }
@@ -78,6 +82,7 @@ export class CommentBrowser extends Window {
       this.commentGroups = {}; // dict Morph id -> Comment group morph
       this.resolvedCommentGroups = {};
       this.wasOpenedBefore = false;
+      this.showsResolvedComments = false;
 
       this.buildContainers();
       this.buildFilterSelector();

--- a/lively.collab/comments/commentMorph.js
+++ b/lively.collab/comments/commentMorph.js
@@ -194,7 +194,7 @@ export class CommentMorph extends Morph {
   initializeCommentIndicator () {
     this.commentIndicator = new CommentIndicator(this, this.comment, this.referenceMorph);
     this.commentIndicator.fontColor = this.comment.isResolved() ? Color.rgb(174, 214, 241) : Color.rgb(241, 196, 15);
-    if (CommentBrowser.isOpen() && (this.comment.isResolved() == CommentBrowser.instance.showsResolvedComments)) {
+    if (CommentBrowser.isOpen() && (this.comment.isResolved() == CommentBrowser.showsArchive())) {
       this.showCommentIndicator();
     }
   }


### PR DESCRIPTION
**Reason for the bug:** Loose comparison of `false` and `undefined` (equals `false`, which was not intended)
**Further notes:** Violation of Law of demeter
**Solution:**
    - Extension of the CommentBrowser interface by `showsArchive` which always returns a boolean and makes violations of Law of demeter unnecessary.
    - Proper initialization of the internal variable of CommentBrowser

**Take aways:** Always make sure to use `!!variable` if you plan to receive a positive boolean