### PR TITLE
Copy comments

### DIFF
--- a/lively.collab/comments/commentIndicator.js
+++ b/lively.collab/comments/commentIndicator.js
@@ -4,6 +4,10 @@ import { connect, disconnect, disconnectAll } from 'lively.bindings';
 import { CommentBrowser } from 'lively.collab';
 
 export class CommentIndicator extends Label {
+  get isCommentIndicator () {
+    return true;
+  }
+
   constructor (commentMorph, comment, referenceMorph) {
     super();
     this.referenceMorph = referenceMorph;
@@ -70,8 +74,7 @@ export class CommentIndicator extends Label {
     $world.addMorph(this);
   }
 
-  copy (trueCopy) {
-    // this is to keep it from copying itself when it was accidentally selected
+  canBeCopied () {
     return false;
   }
 

--- a/lively.collab/comments/commentIndicator.js
+++ b/lively.collab/comments/commentIndicator.js
@@ -70,6 +70,11 @@ export class CommentIndicator extends Label {
     $world.addMorph(this);
   }
 
+  copy (trueCopy) {
+    // this is to keep it from copying itself when it was accidentally selected
+    return false;
+  }
+
   referenceMoving () {
     this._referenceMorphMoving = true;
     this.alignWithMorph();

--- a/lively.collab/tests/browser-test.js
+++ b/lively.collab/tests/browser-test.js
@@ -111,7 +111,7 @@ describe('comment browser', function () {
 });
 
 describe('comment indicator', function () {
-  let morph, browser, comment;
+  let morph, browser, comment, indicatorCount;
   const exampleText = 'Example text';
   const exampleName = 'a test morph';
 
@@ -121,12 +121,14 @@ describe('comment indicator', function () {
     new CommentBrowser();
     browser = CommentBrowser.instance; // This shouldn't be neccessary
     await CommentBrowser.whenRendered();
+    indicatorCount = browser.getUnresolvedCommentCount();
     comment = await morph.addComment(exampleText);
   });
 
   it('is visible when browser is open', function () {
     CommentBrowser.open();
-    expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == 1).to.be.ok;
+    console.log(indicatorCount);
+    expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == indicatorCount + 1).to.be.ok;
   });
 
   it('is hidden when browser is not open', function () {
@@ -136,7 +138,7 @@ describe('comment indicator', function () {
   it('does not get copied when morph with comment is copied', function () {
     CommentBrowser.open();
     const copiedMorph = morph.copy(true);
-    expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == 1).to.be.ok;
+    expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == indicatorCount + 1).to.be.ok;
     copiedMorph.remove();
   });
 

--- a/lively.collab/tests/browser-test.js
+++ b/lively.collab/tests/browser-test.js
@@ -10,6 +10,7 @@ describe('comment browser', function () {
   const exampleName = 'a test morph';
   let browser;
   let comment;
+
   beforeEach(async function () {
     morph = new Morph();
     morph.name = exampleName;
@@ -100,6 +101,43 @@ describe('comment browser', function () {
       }
     });
     expect(commentMorphLabel).to.be.not.ok;
+  });
+
+  afterEach(function () {
+    CommentBrowser.close();
+    morph.emptyComments();
+    morph.remove();
+  });
+});
+
+describe('comment indicator', function () {
+  let morph, browser, comment;
+  const exampleText = 'Example text';
+  const exampleName = 'a test morph';
+
+  beforeEach(async function () {
+    morph = new Morph();
+    morph.name = exampleName;
+    new CommentBrowser();
+    browser = CommentBrowser.instance; // This shouldn't be neccessary
+    await CommentBrowser.whenRendered();
+    comment = await morph.addComment(exampleText);
+  });
+
+  it('is visible when browser is open', function () {
+    CommentBrowser.open();
+    expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == 1).to.be.ok;
+  });
+
+  it('is hidden when browser is not open', function () {
+    expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == 0).to.be.ok;
+  });
+
+  it('does not get copied when morph with comment is copied', function () {
+    CommentBrowser.open();
+    const copiedMorph = morph.copy(true);
+    expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == 1).to.be.ok;
+    copiedMorph.remove();
   });
 
   afterEach(function () {

--- a/lively.collab/tests/browser-test.js
+++ b/lively.collab/tests/browser-test.js
@@ -127,7 +127,6 @@ describe('comment indicator', function () {
 
   it('is visible when browser is open', function () {
     CommentBrowser.open();
-    console.log(indicatorCount);
     expect($world.submorphs.filter((submorph) => submorph.isCommentIndicator).length == indicatorCount + 1).to.be.ok;
   });
 

--- a/lively.collab/tests/comment-class-test.js
+++ b/lively.collab/tests/comment-class-test.js
@@ -69,10 +69,12 @@ describe('morph', function () {
     expect(morphHasNoComments(morph)).to.be.ok;
   });
 
-  it('can be cloned to with equal comment', async function () {
+  it('with comments can be copied to morph with empty comments', async function () {
     comment = await morph.addComment(exampleText);
-    const morph2 = morph.copy();
-    expect(morph.comments[0].equals(morph2.comments[0])).to.be.ok;
+    const morph2 = morph.copy(true);
+    expect(morph2.comments.length == 0).to.be.ok;
+    expect(morph.comments[0].equals(comment)).to.be.ok;
+    morph2.remove();
   });
 
   afterEach(async function () {

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -1375,9 +1375,7 @@ class CopyHaloItem extends HaloItem {
     const { halo } = this; const { target } = halo; const world = halo.world();
     const isMultiSelection = target instanceof MultiSelectionTarget;
     halo.remove();
-
     connect(hand, 'update', this, 'update');
-
     if (isMultiSelection) {
       // FIXME! haaaaack
       const copies = target.selectedMorphs.map(ea => {

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -1456,7 +1456,7 @@ class CopyHaloItem extends HaloItem {
     const origin = t.globalBounds().topLeft();
     // the original morphs are needed so we can refocus them with a halo after copying
     const morphsToCopy = isMultiSelection ? t.selectedMorphs : [t];
-    const modified_morphsToCopy = morphsToCopy.filter(morph => !morph.isCommentIndicator).map(morph => morph.copy(true));
+    const modifiedMorphsToCopy = morphsToCopy.filter(morph => !morph.isCommentIndicator).map(morph => morph.copy(true));
     const snapshots = [];
     let html = `<!DOCTYPE html>
           <html lang="en">
@@ -1468,7 +1468,7 @@ class CopyHaloItem extends HaloItem {
 
     halo.remove(); // we do not want to copy the halo
     try {
-      for (const m of modified_morphsToCopy) {
+      for (const m of modifiedMorphsToCopy) {
         const snap = await createMorphSnapshot(m, { addPreview: false, testLoad: false });
         snap.copyMeta = { offset: m.worldPoint(pt(0, 0)).subPt(origin) };
         snapshots.push(snap);

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -1380,7 +1380,7 @@ class CopyHaloItem extends HaloItem {
 
     if (isMultiSelection) {
       // FIXME! haaaaack
-      const copies = target.selectedMorphs.map(ea => world.addMorph(ea.copy()));
+      const copies = target.selectedMorphs.map(ea => world.addMorph(ea.copy(true)));
       const positions = copies.map(ea => { ea.name = findNewName(target, ea.name); return ea.position; });
       copies[0].undoStart('copy-halo');
       world.addMorph(halo);
@@ -1451,7 +1451,7 @@ class CopyHaloItem extends HaloItem {
     const origin = t.globalBounds().topLeft();
     // the original morphs are needed so we can refocus them with a halo after copying
     const orig_morphsToCopy = isMultiSelection ? t.selectedMorphs : [t];
-    debugger;
+    // debugger;
     const modified_morphsToCopy = orig_morphsToCopy.forEach(m => m.copy(true));
     const snapshots = [];
     let html = `<!DOCTYPE html>

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -1379,9 +1379,8 @@ class CopyHaloItem extends HaloItem {
     if (isMultiSelection) {
       // FIXME! haaaaack
       const copies = target.selectedMorphs.map(ea => {
-        const copy = ea.copy(true);
-        // allows to not include morphs that return a falsy value on copy
-        if (copy) {
+        if (ea.canBeCopied()) {
+          const copy = ea.copy(true);
           world.addMorph(copy);
           return copy;
         }
@@ -1457,7 +1456,7 @@ class CopyHaloItem extends HaloItem {
     const origin = t.globalBounds().topLeft();
     // the original morphs are needed so we can refocus them with a halo after copying
     const morphsToCopy = isMultiSelection ? t.selectedMorphs : [t];
-    const modified_morphsToCopy = morphsToCopy.filter(m => !(m instanceof CommentIndicator)).map(m => m.copy(true));
+    const modified_morphsToCopy = morphsToCopy.filter(morph => !morph.isCommentIndicator).map(morph => morph.copy(true));
     const snapshots = [];
     let html = `<!DOCTYPE html>
           <html lang="en">

--- a/lively.halos/morph.js
+++ b/lively.halos/morph.js
@@ -13,7 +13,7 @@ import { obj, Path as PropertyPath, promise, properties, num, arr } from 'lively
 import { connect, signal, disconnect, disconnectAll, once } from 'lively.bindings';
 
 import { showAndSnapToGuides, showAndSnapToResizeGuides, removeSnapToGuidesOf } from './drag-guides.js';
-import { CommentBrowser } from 'lively.collab';
+import { CommentBrowser, CommentIndicator } from 'lively.collab';
 import { resource } from 'lively.resources';
 import { show } from './markers.js';
 
@@ -1449,7 +1449,10 @@ class CopyHaloItem extends HaloItem {
     const world = halo.world();
     const isMultiSelection = t instanceof MultiSelectionTarget;
     const origin = t.globalBounds().topLeft();
-    const morphsToCopy = isMultiSelection ? t.selectedMorphs : [t];
+    // the original morphs are needed so we can refocus them with a halo after copying
+    const orig_morphsToCopy = isMultiSelection ? t.selectedMorphs : [t];
+    debugger;
+    const modified_morphsToCopy = orig_morphsToCopy.forEach(m => m.copy(true));
     const snapshots = [];
     let html = `<!DOCTYPE html>
           <html lang="en">
@@ -1461,7 +1464,7 @@ class CopyHaloItem extends HaloItem {
 
     halo.remove(); // we do not want to copy the halo
     try {
-      for (const m of morphsToCopy) {
+      for (const m of modified_morphsToCopy) {
         const snap = await createMorphSnapshot(m, { addPreview: false, testLoad: false });
         snap.copyMeta = { offset: m.worldPoint(pt(0, 0)).subPt(origin) };
         snapshots.push(snap);
@@ -1478,7 +1481,7 @@ class CopyHaloItem extends HaloItem {
       ]);
     } catch (e) { world.logError(e); return; }
     world.addMorph(halo);
-    halo.refocus(morphsToCopy);
+    halo.refocus(orig_morphsToCopy);
     halo.setStatusMessage('copied');
   }
 

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2538,6 +2538,7 @@ export class Morph {
   }
 
   emptyComments () {
+    console.log(this.comments);
     this.comments.forEach((comment) => CommentBrowser.removeCommentForMorph(comment, this));
     this.comments = [];
   }

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2382,6 +2382,7 @@ export class Morph {
     return morph({ type: exported.type }).initFromJSON(exported);
   }
 
+  canBeCopied () { return true; }
   copy (realCopy = false) { return copyMorph(this, realCopy); }
 
   async interactivelyPublish () {
@@ -2538,7 +2539,6 @@ export class Morph {
   }
 
   emptyComments () {
-    console.log(this.comments);
     this.comments.forEach((comment) => CommentBrowser.removeCommentForMorph(comment, this));
     this.comments = [];
   }

--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -2382,7 +2382,7 @@ export class Morph {
     return morph({ type: exported.type }).initFromJSON(exported);
   }
 
-  copy () { return copyMorph(this); }
+  copy (realCopy = false) { return copyMorph(this, realCopy); }
 
   async interactivelyPublish () {
     const world = this.world() || this.env.world;

--- a/lively.morphic/serialization.js
+++ b/lively.morphic/serialization.js
@@ -92,13 +92,15 @@ export function copyMorph (morph, realCopy = false) {
   let cachedConnections = [];
   if (morph.attributeConnections) {
     cachedConnections = morph.attributeConnections.filter(ac => ac.targetObj instanceof CommentIndicator);
-    morph.attributeConnections = morph.attributeConnections.filter(ac => !(ac.targetObj instanceof CommentIndicator));
+    morph.attributeConnections = morph.attributeConnections.filter(ac => !(ac.targetObj instanceof CommentIndicator || ac.targetObj instanceof Halo));
   }
 
   const serializedMorph = serializeMorph(morph);
 
   morph.comments = cachedComments;
-  morph.attributeConnections = morph.attributeConnections.concat(cachedConnections);
+  if (morph.attributeConnections) {
+    morph.attributeConnections = morph.attributeConnections.concat(cachedConnections);
+  }
 
   return deserializeMorph(serializedMorph, { migrations, reinitializeIds: true });
 }
@@ -110,6 +112,7 @@ import { createFiles } from 'lively.resources';
 import { promise, graph, arr } from 'lively.lang';
 import { migrations } from './object-migration.js';
 import { CommentIndicator } from 'lively.collab';
+import { Halo } from 'lively.halos';
 
 const { registerPackage, module, getPackage, ensurePackage, lookupPackage, semver } = modules;
 

--- a/lively.morphic/serialization.js
+++ b/lively.morphic/serialization.js
@@ -89,9 +89,6 @@ export function copyMorph (morph, realCopy = false) {
   const cachedComments = morph.comments;
   morph.comments = [];
 
-  const cachedSubmorphs = morph.submorphs.filter(sm => sm instanceof CommentIndicator);
-  morph.submorphs = morph.submorphs.filter(sm => !(sm instanceof CommentIndicator));
-
   let cachedConnections = [];
   if (morph.attributeConnections) {
     cachedConnections = morph.attributeConnections.filter(ac => ac.targetObj instanceof CommentIndicator);
@@ -100,7 +97,6 @@ export function copyMorph (morph, realCopy = false) {
 
   const serializedMorph = serializeMorph(morph);
 
-  morph.submorphs = morph.submorphs.concat(cachedSubmorphs);
   morph.comments = cachedComments;
   morph.attributeConnections = morph.attributeConnections.concat(cachedConnections);
 

--- a/lively.morphic/serialization.js
+++ b/lively.morphic/serialization.js
@@ -91,8 +91,8 @@ export function copyMorph (morph, realCopy = false) {
 
   let cachedConnections = [];
   if (morph.attributeConnections) {
-    cachedConnections = morph.attributeConnections.filter(ac => ac.targetObj instanceof CommentIndicator);
-    morph.attributeConnections = morph.attributeConnections.filter(ac => !(ac.targetObj instanceof CommentIndicator || ac.targetObj instanceof Halo));
+    cachedConnections = morph.attributeConnections.filter(ac => ac.targetObj.isCommentIndicator);
+    morph.attributeConnections = morph.attributeConnections.filter(ac => !(ac.targetObj.isCommentIndicator || ac.targetObj.isHalo));
   }
 
   const serializedMorph = serializeMorph(morph);


### PR DESCRIPTION
This closes https://github.com/hpi-swa-lab/BP2020RH1/issues/73

Some notes on the implementation:

The `copyMorph` method previously was also used for a lot of stuff where copying may not be the word one would intuitively use. We introduced a parameter to this function, that should be true for a "real" copy, i.e., you actually want a deep copy of the morph object.

Then the idea for the copying and pasting is as follows:

1. Cache `CommentIndicators`, Comments,... that the original `Morph` holds
2. Remove these of the original `Morph`
3. Make a copy of the original `Morph` without these
4. Readd the cached elements to the `Morph`

The last thing to do was then handling some tricky cases when multiple `Morphs` are selected. Here we introduced the option to skip the copying from `Morphs` if their `copy` method returns a `falsy` value.

This was tested with short-clicking and dragging of the halo and also Strg-C. 