### PR TITLE
morph: fix deletion when submorph has comment

### DIFF
--- a/lively.morphic/morph.js
+++ b/lively.morphic/morph.js
@@ -1645,6 +1645,7 @@ export class Morph {
     // Use this method to signal the wish to permanently delete this object. Overwrite this method to clean up resources on its deletion. We do not have access to the JS VM, this method does not interact with the garbage collector and does not result in the actual deletion of the object, if there are still left over references to this object.
     this.emptyComments();
     this.remove();
+    this.submorphs.forEach(submorph => submorph.abandon());
   }
 
   onOwnerChanged (newOwner) {


### PR DESCRIPTION
Closes https://github.com/hpi-swa-lab/BP2020RH1/issues/102

The problem was that we never actually emptied all comments for all submorphs when a morph was deleted.

We again could not use the builtin `withAllSubmorphsDo()`, since this method starts calling at the parent level and does not only do something with the submorphs (which makes me irrationaly angry).

